### PR TITLE
Added theme support and handling of utf-8 characters

### DIFF
--- a/linked-wiki-pages/js/viewModel.js
+++ b/linked-wiki-pages/js/viewModel.js
@@ -85,7 +85,7 @@ function getViewModel(model, artifactsServices, artifactsConstants) {
                             model.context.account.uri,
                             model.context.project.name,
                             "/_wiki/wikis/",
-                            segments[1] + "?pagePath=" + pagePathEncoded
+                            segments[1] + "?pagePath=" + encodeURIComponent(pagePathEncoded)
                         ].join("");
 
                         return {

--- a/linked-wiki-pages/js/viewModel.js
+++ b/linked-wiki-pages/js/viewModel.js
@@ -76,8 +76,7 @@ function getViewModel(model, artifactsServices, artifactsConstants) {
                             pageSegments.push(segments[i]);
                         }
 
-                        var pagePathEncoded = pageSegments
-                            .join("/")
+                        var pagePathEncoded = encodeURIComponent(pageSegments.join("/"))
                             // replace all " " with "+"
                             .split(" ").join("+");
 
@@ -85,7 +84,7 @@ function getViewModel(model, artifactsServices, artifactsConstants) {
                             model.context.account.uri,
                             model.context.project.name,
                             "/_wiki/wikis/",
-                            segments[1] + "?pagePath=" + encodeURIComponent(pagePathEncoded)
+                            segments[1] + "?pagePath=" + pagePathEncoded
                         ].join("");
 
                         return {

--- a/linked-wiki-pages/linked-wiki-pages.html
+++ b/linked-wiki-pages/linked-wiki-pages.html
@@ -33,11 +33,6 @@
                         viewModel.reload();
                     },
 
-                    // called when the active work item is modified
-                    onFieldChanged: function(args) {
-                        viewModel.reload();
-                    },
-
                     // called after the work item has been saved
                     onSaved: function (args) {
                         viewModel.reload();

--- a/linked-wiki-pages/linked-wiki-pages.html
+++ b/linked-wiki-pages/linked-wiki-pages.html
@@ -15,7 +15,8 @@
         VSS.init({
             explicitNotifyLoaded: true,
             usePlatformScripts: true,
-            usePlatformStyles: true
+            usePlatformStyles: true,
+            applyTheme: true
         });
 
         var module = function(workItemsTrackingServices, artifactsServices, artifactsConstants) {

--- a/linked-wiki-pages/package.json
+++ b/linked-wiki-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "link-work-to-wiki",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "author": "Anton Boyko",
   "license": "MIT",
   "dependencies": {

--- a/linked-wiki-pages/vss-extension.json
+++ b/linked-wiki-pages/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1.0,
   "id": "linked-wiki-pages",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "name": "Linked Wiki pages",
   "description": "Displays the list of all Wiki pages linked to current Work Item.",
   "publisher": "boykoant",
@@ -33,7 +33,7 @@
     }
   ],
   "categories": [
-    "Plan and track"
+    "Azure Boards"
   ],
   "tags": [
     "wiki"


### PR DESCRIPTION
Successor of #23, solves #22 & #24 & (#20 & #26)

## #22 Background Theme
@boyko-ant, I've updated it so that the user's selected theme is now used in the background of the widget. 

## #24 Non-ASCII character handling
I also updated to handling wiki pages with UTF-8 characters which were based on the changes made by Mikael Ekelund in his fork: https://github.com/stratiteq/Forms/commit/e34430e748d88dc4c78e74a412167f3d3c88da1b. 

However, the change did not work as all the encoding was done after the `" "` to `"+"`, which meant that all spaces got replaced by `%2B` instead of `+` as per DevOps implementation. This PR is confirmed to now also work for UTF-8 characters, such as Ü.

## #20 & #26 Flickering widget when typing

Due to having a listener on `onFieldChanged`, means that whenever any field on the work item, the widget gets reloaded, which creates the undeliverable flickering, that listener is now removed and no longer flickers when typing in any text field.

## Other remarks
Also updated _categories_ as `Plan and track` is not a valid category anymore.

Once these fixes as been pushed, I would highly recommend that @Stratiteq and I (@BlackPhlox) take down our own published extensions of our forks, or at least make a deprecation notice, referencing the original extension as so to prevent confusion for other DevOps users.

Regarding the issue of linking to multiple wikis (#25), it should probably be documented in the description of the extension, that this is a limitation of DevOps and you have to link from the wiki page to work-item instead as shown by this comment: https://github.com/TFSExt/Forms/issues/25#issuecomment-1791081358